### PR TITLE
Fix dishwasher_washzone options

### DIFF
--- a/packages/dishwasher.yaml
+++ b/packages/dishwasher.yaml
@@ -198,7 +198,7 @@ mqtt:
         } %}
         {{ map[value] if value in map }}
       options:
-        - "Off"
+        - "Both"
         - "Lower"
         - "Upper"
       device:


### PR DESCRIPTION
If we put `Off`, then we can never set it to `Both` since `Off` will not map to any of the options.